### PR TITLE
Fix ERC-1271 logic

### DIFF
--- a/src/blocks/AccountUnlock.vue
+++ b/src/blocks/AccountUnlock.vue
@@ -83,8 +83,12 @@ export default {
         await this.$store.dispatch("wallet/restoreProviderConnection");
         this.tip = "Confirm the transaction to unlock this account";
         if (syncWallet.ethSignerType.verificationMethod === "ERC-1271") {
-          const onchainAuthTransaction = await syncWallet.onchainAuthSigningKey();
-          await onchainAuthTransaction.wait();
+          const isOnchainAuthSigningKeySet = await syncWallet.isOnchainAuthSigningKeySet();
+          if (!isOnchainAuthSigningKeySet) {
+            const onchainAuthTransaction = await syncWallet.onchainAuthSigningKey();
+            await onchainAuthTransaction.wait();
+          }
+          
           const isSigningKeySet = await syncWallet.isSigningKeySet();
           if(!isSigningKeySet) {
             const changePubkey = await syncWallet.setSigningKey({
@@ -106,16 +110,9 @@ export default {
         this.tip = "Processing...";
         await this.$store.dispatch("wallet/forceRefreshData");
 
-        if (syncWallet.ethSignerType.verificationMethod === "ERC-1271") {
-          const isOnchainAuthSigningKeySet = await syncWallet.isOnchainAuthSigningKeySet();
-          console.log("isOnchainAuthSigningKeySet", isOnchainAuthSigningKeySet);
-          this.$store.commit("wallet/setAccountLockedState", isOnchainAuthSigningKeySet === false);
-        }
-        else {
-          const isSigningKeySet = await syncWallet.isSigningKeySet();
-          console.log("isSigningKeySet", isSigningKeySet);
-          this.$store.commit("wallet/setAccountLockedState", isSigningKeySet === false);
-        }
+        const isSigningKeySet = await syncWallet.isSigningKeySet();
+        console.log("isSigningKeySet", isSigningKeySet);
+        this.$store.commit("wallet/setAccountLockedState", isSigningKeySet === false);
 
         const newAccountState = await syncWallet.getAccountState();
         walletData.set({ accountState: newAccountState });

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -488,15 +488,8 @@ export const actions = {
       await dispatch("getzkBalances", accountState);
 
       const isSigningKeySet = await syncWallet.isSigningKeySet();
+      commit("setAccountLockedState", isSigningKeySet === false);
       console.log("isSigningKeySet", isSigningKeySet);
-      if (syncWallet.ethSignerType.verificationMethod === "ERC-1271") {
-        const isOnchainAuthSigningKeySet = await syncWallet.isOnchainAuthSigningKeySet();
-        console.log("isOnchainAuthSigningKeySet", isOnchainAuthSigningKeySet);
-        commit("setAccountLockedState", !(isSigningKeySet === true && isOnchainAuthSigningKeySet === true));
-      }
-      else {
-        commit("setAccountLockedState", isSigningKeySet === false);
-      }
 
       dispatch("changeNetworkSet");
       this.commit("account/setAddress", syncWallet.address());


### PR DESCRIPTION
Fix ERC-1271 wallet unlocking logic

## Description
`isSigningKeySet` to check if the wallet has the signing key set, but not enough to set it.

## Motivation and Context
ERC-1271 unlocking was not working sometimes

