### PR TITLE
Disable Service Worker cache for .html files

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -167,4 +167,9 @@ export default {
     dir: "public",
     fallback: "404.html",
   },
+  pwa: {
+    workbox: {
+      'pagesURLPattern': '/_nuxt/'
+    }
+  }
 };


### PR DESCRIPTION
Basically, that means enabling caches only for the `/_nuxt` folder (there are no .html files there but it contributes the total majority of the size of the webpage).

Somehow caching `.html` files prevented native login with Trust and MYKEY wallets.